### PR TITLE
Fail and delay batch items

### DIFF
--- a/AzureBatchQueue.Tests/BatchQueueTests.cs
+++ b/AzureBatchQueue.Tests/BatchQueueTests.cs
@@ -101,50 +101,6 @@ public class BatchQueueTests
     }
 
     [Test]
-    public async Task When_batch_updates_with_smallest_visibility_timeout_if_present()
-    {
-        using var queueTest = await Queue<string>();
-
-        var messageBatch = new[] { "orange", "banana", "apple", "pear", "strawberry" };
-        await queueTest.BatchQueue.Send(messageBatch);
-
-        var longVisibilityTimeout = TimeSpan.FromSeconds(10);
-        var firstReceive = await queueTest.BatchQueue.Receive(visibilityTimeout: longVisibilityTimeout);
-        firstReceive.Select(x => x.Item).Should().BeEquivalentTo(messageBatch);
-
-        foreach (var item in firstReceive)
-        {
-            if (item.Item == "orange")
-            {
-                item.Delay(TimeSpan.FromSeconds(1)); // small delay
-                continue;
-            }
-
-            if (item.Item == "pear")
-            {
-                item.Delay(TimeSpan.FromHours(1)); // huge delay
-                continue;
-            }
-
-            item.Complete();
-        }
-
-        // wait for message to flush
-        await Task.Delay(TimeSpan.FromMilliseconds(10));
-
-        // try to complete batch item again, but catch an exception that everything was already processed
-        Assert.Throws<BatchCompletedException>(() => firstReceive.First().Complete())!
-            .BatchCompletedResult.Should().Be(BatchCompletedResult.PartialFailure);
-
-        // wait for message to be visible after smallest delay time
-        await Task.Delay(TimeSpan.FromSeconds(1.1));
-
-        // message was updated with delayed items
-        var secondReceive = await queueTest.BatchQueue.Receive(visibilityTimeout: longVisibilityTimeout);
-        secondReceive.Select(x => x.Item).Should().BeEquivalentTo("orange", "pear");
-    }
-
-    [Test]
     public async Task When_batch_flushes_after_all_complete_or_fail()
     {
         using var queueTest = await Queue<string>();

--- a/AzureBatchQueue/BatchItem.cs
+++ b/AzureBatchQueue/BatchItem.cs
@@ -17,6 +17,7 @@ public class BatchItem<T>
     public BatchItemMetadata Metadata { get; }
 
     public void Complete() => Batch.Complete(Id);
+    public void Fail() => Batch.Fail(Id);
 }
 
 public record BatchItemId(string BatchId, int Idx)

--- a/AzureBatchQueue/BatchItem.cs
+++ b/AzureBatchQueue/BatchItem.cs
@@ -18,7 +18,6 @@ public class BatchItem<T>
 
     public void Complete() => Batch.Complete(Id);
     public void Fail() => Batch.Fail(Id);
-    public void Delay(TimeSpan delay) => Batch.Delay(Id, delay);
 }
 
 public record BatchItemId(string BatchId, int Idx)

--- a/AzureBatchQueue/BatchItem.cs
+++ b/AzureBatchQueue/BatchItem.cs
@@ -18,6 +18,7 @@ public class BatchItem<T>
 
     public void Complete() => Batch.Complete(Id);
     public void Fail() => Batch.Fail(Id);
+    public void Delay(TimeSpan delay) => Batch.Delay(Id, delay);
 }
 
 public record BatchItemId(string BatchId, int Idx)

--- a/AzureBatchQueue/BatchQueue.cs
+++ b/AzureBatchQueue/BatchQueue.cs
@@ -47,7 +47,7 @@ public class BatchQueue<T>
     public async Task ClearMessages() => await queue.ClearMessages();
 
     public async Task DeleteMessage(MessageId msgId, CancellationToken ct = default) => await queue.DeleteMessage(msgId, ct);
-    public async Task UpdateMessage(MessageId id, T[] items, TimeSpan visibilityTimeout = default, CancellationToken ct = default) => await queue.UpdateMessage(id, items, visibilityTimeout, ct: ct);
+    public async Task UpdateMessage(MessageId id, T[] items, CancellationToken ct = default) => await queue.UpdateMessage(id, items, ct: ct);
 
     public async Task QuarantineData(MessageId id, T[] items)
     {

--- a/AzureBatchQueue/BatchQueue.cs
+++ b/AzureBatchQueue/BatchQueue.cs
@@ -47,7 +47,7 @@ public class BatchQueue<T>
     public async Task ClearMessages() => await queue.ClearMessages();
 
     public async Task DeleteMessage(MessageId msgId, CancellationToken ct = default) => await queue.DeleteMessage(msgId, ct);
-    public async Task UpdateMessage(MessageId id, T[] items, CancellationToken ct = default) => await queue.UpdateMessage(id, items, ct: ct);
+    public async Task UpdateMessage(MessageId id, T[] items, TimeSpan visibilityTimeout = default, CancellationToken ct = default) => await queue.UpdateMessage(id, items, visibilityTimeout, ct: ct);
 
     public async Task QuarantineData(MessageId id, T[] items)
     {

--- a/AzureBatchQueue/TimerBatch.cs
+++ b/AzureBatchQueue/TimerBatch.cs
@@ -17,6 +17,7 @@ internal class TimerBatch<T>
 
     bool flushTriggered;
     readonly object locker = new();
+    TimeSpan minVisibilityTimeout;
 
     public TimerBatch(BatchQueue<T> batchQueue, QueueMessage<T[]> msg, int maxDequeueCount, ILogger logger)
     {
@@ -93,17 +94,19 @@ internal class TimerBatch<T>
             async Task Update()
             {
                 var remaining = Remaining();
-                await batchQueue.UpdateMessage(msg.MessageId, remaining);
+                await batchQueue.UpdateMessage(msg.MessageId, remaining, visibilityTimeout: minVisibilityTimeout);
 
                 logger.LogWarning("Message {MsgId} was not fully processed within a timeout ({FlushPeriod}) sec in queue {QueueName}." +
-                                  " {RemainingCount} items were not completed ({NotProcessed} not processed on time and {FailedCount} failed) from {TotalCount} total",
+                                  " {RemainingCount} items were not completed ({NotProcessed} not processed on time and {FailedCount} failed) from {TotalCount} total." +
+                                   " VisibilityTimeout for updated message is {VisibilityTimeout}",
                     msg.MessageId,
                     FlushPeriod.TotalSeconds,
                     batchQueue.Name,
                     remaining.Length,
                     NotProcessedCount(),
                     FailedCount(),
-                    items.Items().Length);
+                    items.Items().Length,
+                    minVisibilityTimeout);
             }
 
             async Task Delete()
@@ -149,6 +152,18 @@ internal class TimerBatch<T>
         ThrowIfCompleted(itemId);
 
         var remaining = items.Fail(itemId);
+
+        FlushIfEmpty(remaining);
+    }
+
+    public void Delay(BatchItemId itemId, TimeSpan delayTime)
+    {
+        ThrowIfCompleted(itemId);
+
+        var remaining = items.Fail(itemId);
+
+        if (minVisibilityTimeout == default || minVisibilityTimeout > delayTime)
+            minVisibilityTimeout = delayTime;
 
         FlushIfEmpty(remaining);
     }


### PR DESCRIPTION
## Fail
When only failed items left -> update message with these items.
When flush is triggered by timeout -> update message with both failed and not processed items.

## Delay
When one or more items are delayed -> update message with failed and not processed items with a **minimum** visibility timeout present.

We consider a situation when a batch is triggered by timeout together with a visibility timeout a very rare situation. So we don't care that other items in a batch are affected by a visibility timeout of another item.